### PR TITLE
Fix applying color on Obsidian v1.2.7

### DIFF
--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -14,7 +14,7 @@ interface ExplorerView extends View {
   fileItems: Record<
     string,
     {
-      titleEl: HTMLDivElement
+      selfEl: HTMLDivElement
     }
   >
 }

--- a/src/plugin/FileColorPlugin.ts
+++ b/src/plugin/FileColorPlugin.ts
@@ -101,7 +101,7 @@ export class FileColorPlugin extends Plugin {
     fileExplorers.forEach((fileExplorer) => {
       Object.entries(fileExplorer.view.fileItems).forEach(
         ([path, fileItem]) => {
-          const itemClasses = fileItem.titleEl.classList.value
+          const itemClasses = fileItem.selfEl.classList.value
             .split(' ')
             .filter((cls) => !cls.startsWith('file-color'))
           const file = this.settings.fileColors.find(
@@ -113,7 +113,7 @@ export class FileColorPlugin extends Plugin {
             itemClasses.push('file-color-color-' + file.color)
           }
 
-          fileItem.titleEl.classList.value = itemClasses.join(' ')
+          fileItem.selfEl.classList.value = itemClasses.join(' ')
         }
       )
     })


### PR DESCRIPTION
The property name changed from `titleEl` to `selfEl`. Closes #11 and closes #12.

Temporary workaround:
1. Open `main.js`.
2. Find `titleEl` in the file. There should be 3 occurences.
3. Replace the last 2 occurences of `titleEl` with `selfEl`.
4. Save the file and restart Obsidian.
