### PR TITLE
Implement color inheritance and background colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ To add colors to the palette open the plugin settings, and click the `+` button.
 
 ### Options
 
-- Color Inheritance: if turned on, sub-folders and notes inherit colors from parents. Set colors on children folders/notes to override parents.
-- Color Background: if turned on, the background is colored instead of the text.
+- Cascade Colors: if turned on, colors on folders will cascade to their children. Set colors on children to override parents.
+- Background COlors: if turned on, the background is colored instead of the text.
 
 ## Compatibility
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ To add colors to the palette open the plugin settings, and click the `+` button.
 
 ![Adding a color](./docs/images/add-color-rounded.gif)
 
+### Options
+
+- Color Inheritance: if turned on, sub-folders and notes inherit colors from parents. Set colors on children folders/notes to override parents.
+- Color Background: if turned on, the background is colored instead of the text.
+
 ## Compatibility
 
 This plugin has been tested with a few other community plugins:

--- a/src/components/SettingItem/index.tsx
+++ b/src/components/SettingItem/index.tsx
@@ -25,3 +25,9 @@ export const SettingItemInfo = ({
 }: HTMLProps<HTMLDivElement>) => (
   <div className={`setting-item-info${className ? ' ' + className : ''}`} {...props} />
 )
+export const SettingItemDescription = ({
+  className,
+  ...props
+}: HTMLProps<HTMLDivElement>) => (
+  <div className={`setting-item-description${className ? ' ' + className : ''}`} {...props} />
+)

--- a/src/modules/SettingsPanel/index.tsx
+++ b/src/modules/SettingsPanel/index.tsx
@@ -7,8 +7,10 @@ import React, { useEffect, useState } from 'react'
 import type { FileColorPluginSettings } from 'settings'
 import {
   SettingItem,
+  SettingItemName,
   SettingItemControl,
   SettingItemInfo,
+  SettingItemDescription
 } from 'components/SettingItem'
 import { SettingItemControlFull } from './SettingItemControlFull'
 import { WideTextInput } from './WideTextInput'
@@ -19,6 +21,9 @@ export const SettingsPanel = () => {
   const plugin = usePlugin()
   const [palette, setPalette] = useState<FileColorPluginSettings['palette']>(
     plugin.settings.palette
+  )
+  const [inheritColors, setInheritColors] = useState<FileColorPluginSettings['inheritColors']>(
+    plugin.settings.inheritColors
   )
   const [changed, setChanged] = useState<boolean>(false)
 
@@ -98,6 +103,13 @@ export const SettingsPanel = () => {
     setChanged(false)
   }
 
+  const onChangeInheritColors = () => {
+    setInheritColors(!inheritColors)
+    plugin.settings.inheritColors = !plugin.settings.inheritColors
+    plugin.saveSettings()
+    plugin.applyColorStyles()
+  }
+
   return (
     <div className="file-color-settings-panel">
       <h2>Palette</h2>
@@ -133,7 +145,7 @@ export const SettingsPanel = () => {
       {changed && (
         <SettingItem className="file-color-settings-save">
           <SettingItemInfo>
-            <span className="mod-warning">You have unsaved changes.</span>
+            <span className="mod-warning">You have unsaved palette changes.</span>
           </SettingItemInfo>
           <SettingItemControl>
             <Button onClick={onRevert}>Revert changes</Button>
@@ -141,6 +153,22 @@ export const SettingsPanel = () => {
           </SettingItemControl>
         </SettingItem>
       )}
+
+      <h2>Options</h2>
+      <SettingItem className='mod-toggle'>
+        <SettingItemInfo>
+          <SettingItemName>Color Inheritance</SettingItemName>
+          <SettingItemDescription>Sub-folders and notes inherit colors from parents unless their colors are explicitly set.</SettingItemDescription>
+        </SettingItemInfo>
+       
+        <SettingItemControl>
+          <div className={'checkbox-container'+(inheritColors?' is-enabled':'')} onClick={onChangeInheritColors}>
+            <input type='checkbox'></input>
+          </div>
+        </SettingItemControl>
+      </SettingItem>
+
+      
     </div>
   )
 }

--- a/src/modules/SettingsPanel/index.tsx
+++ b/src/modules/SettingsPanel/index.tsx
@@ -110,7 +110,6 @@ export const SettingsPanel = () => {
     setInheritColors(!inheritColors)
     plugin.settings.inheritColors = !plugin.settings.inheritColors
     plugin.saveSettings()
-    plugin.clearStyles()
     plugin.applyColorStyles()
   }
 
@@ -118,7 +117,6 @@ export const SettingsPanel = () => {
     setColorBackground(!colorBackground)
     plugin.settings.colorBackground = !plugin.settings.colorBackground
     plugin.saveSettings()
-    plugin.clearStyles()
     plugin.applyColorStyles()
   }
 

--- a/src/modules/SettingsPanel/index.tsx
+++ b/src/modules/SettingsPanel/index.tsx
@@ -25,6 +25,9 @@ export const SettingsPanel = () => {
   const [inheritColors, setInheritColors] = useState<FileColorPluginSettings['inheritColors']>(
     plugin.settings.inheritColors
   )
+  const [colorBackground, setColorBackground] = useState<FileColorPluginSettings['colorBackground']>(
+    plugin.settings.colorBackground
+  )
   const [changed, setChanged] = useState<boolean>(false)
 
   useEffect(() => {
@@ -107,6 +110,15 @@ export const SettingsPanel = () => {
     setInheritColors(!inheritColors)
     plugin.settings.inheritColors = !plugin.settings.inheritColors
     plugin.saveSettings()
+    plugin.clearStyles()
+    plugin.applyColorStyles()
+  }
+
+  const onChangeColorBackground = () => {
+    setColorBackground(!colorBackground)
+    plugin.settings.colorBackground = !plugin.settings.colorBackground
+    plugin.saveSettings()
+    plugin.clearStyles()
     plugin.applyColorStyles()
   }
 
@@ -163,6 +175,19 @@ export const SettingsPanel = () => {
        
         <SettingItemControl>
           <div className={'checkbox-container'+(inheritColors?' is-enabled':'')} onClick={onChangeInheritColors}>
+            <input type='checkbox'></input>
+          </div>
+        </SettingItemControl>
+      </SettingItem>
+
+      <SettingItem className='mod-toggle'>
+        <SettingItemInfo>
+          <SettingItemName>Color Background</SettingItemName>
+          <SettingItemDescription>Color the background instead of the text.</SettingItemDescription>
+        </SettingItemInfo>
+       
+        <SettingItemControl>
+          <div className={'checkbox-container'+(colorBackground?' is-enabled':'')} onClick={onChangeColorBackground}>
             <input type='checkbox'></input>
           </div>
         </SettingItemControl>

--- a/src/modules/SettingsPanel/index.tsx
+++ b/src/modules/SettingsPanel/index.tsx
@@ -22,8 +22,8 @@ export const SettingsPanel = () => {
   const [palette, setPalette] = useState<FileColorPluginSettings['palette']>(
     plugin.settings.palette
   )
-  const [inheritColors, setInheritColors] = useState<FileColorPluginSettings['inheritColors']>(
-    plugin.settings.inheritColors
+  const [cascadeColors, setCascadeColors] = useState<FileColorPluginSettings['cascadeColors']>(
+    plugin.settings.cascadeColors
   )
   const [colorBackground, setColorBackground] = useState<FileColorPluginSettings['colorBackground']>(
     plugin.settings.colorBackground
@@ -106,9 +106,9 @@ export const SettingsPanel = () => {
     setChanged(false)
   }
 
-  const onChangeInheritColors = () => {
-    setInheritColors(!inheritColors)
-    plugin.settings.inheritColors = !plugin.settings.inheritColors
+  const onChangeCascadeColors = () => {
+    setCascadeColors(!cascadeColors)
+    plugin.settings.cascadeColors = !plugin.settings.cascadeColors
     plugin.saveSettings()
     plugin.applyColorStyles()
   }
@@ -167,12 +167,12 @@ export const SettingsPanel = () => {
       <h2>Options</h2>
       <SettingItem className='mod-toggle'>
         <SettingItemInfo>
-          <SettingItemName>Color Inheritance</SettingItemName>
-          <SettingItemDescription>Sub-folders and notes inherit colors from parents unless their colors are explicitly set.</SettingItemDescription>
+          <SettingItemName>Cascade Colors</SettingItemName>
+          <SettingItemDescription>Folders will cascade their colors to sub-folders and notes, unless their colors are explicitly set.</SettingItemDescription>
         </SettingItemInfo>
        
         <SettingItemControl>
-          <div className={'checkbox-container'+(inheritColors?' is-enabled':'')} onClick={onChangeInheritColors}>
+          <div className={'checkbox-container'+(cascadeColors?' is-enabled':'')} onClick={onChangeCascadeColors}>
             <input type='checkbox'></input>
           </div>
         </SettingItemControl>

--- a/src/plugin/FileColorPlugin.ts
+++ b/src/plugin/FileColorPlugin.ts
@@ -97,8 +97,6 @@ export class FileColorPlugin extends Plugin {
   applyColorStyles = debounce(this.applyColorStylesInternal, 50, true);
 
   private applyColorStylesInternal() {
-    // If inheriting colors, the "el" element will include a folder and all its sub-items.
-    // Otherwise, selfEl will color only itself, whether folder or note
     let cssType = this.settings.colorBackground ? 'background' : 'text'
 
     const fileExplorers = this.app.workspace.getLeavesOfType('file-explorer')
@@ -117,7 +115,7 @@ export class FileColorPlugin extends Plugin {
             itemClasses.push('file-color-file')
             itemClasses.push('file-color-color-' + file.color)
             itemClasses.push('file-color-type-' + cssType)
-            if (this.settings.inheritColors) {
+            if (this.settings.cascadeColors) {
               itemClasses.push('file-color-cascade')
             }
           }

--- a/src/plugin/FileColorPlugin.ts
+++ b/src/plugin/FileColorPlugin.ts
@@ -99,14 +99,13 @@ export class FileColorPlugin extends Plugin {
   private applyColorStylesInternal() {
     // If inheriting colors, the "el" element will include a folder and all its sub-items.
     // Otherwise, selfEl will color only itself, whether folder or note
-    let elementType = this.settings.inheritColors ? 'el' : 'selfEl',
-      cssType = this.settings.colorBackground ? 'background' : 'text'
+    let cssType = this.settings.colorBackground ? 'background' : 'text'
 
     const fileExplorers = this.app.workspace.getLeavesOfType('file-explorer')
     fileExplorers.forEach((fileExplorer) => {
       Object.entries(fileExplorer.view.fileItems).forEach(
         ([path, fileItem]) => {
-          const itemClasses = fileItem[elementType].classList.value
+          const itemClasses = fileItem.el.classList.value
             .split(' ')
             .filter((cls) => !cls.startsWith('file-color'))
 
@@ -118,30 +117,15 @@ export class FileColorPlugin extends Plugin {
             itemClasses.push('file-color-file')
             itemClasses.push('file-color-color-' + file.color)
             itemClasses.push('file-color-type-' + cssType)
+            if (this.settings.inheritColors) {
+              itemClasses.push('file-color-cascade')
+            }
           }
 
-          fileItem[elementType].classList.value = itemClasses.join(' ')
+          fileItem.el.classList.value = itemClasses.join(' ')
         }
       )
     })
   }
 
-  /**
-   * Clears color style classes from all elements we can possibly color.
-   */
-  clearStyles() {
-    const fileExplorers = this.app.workspace.getLeavesOfType('file-explorer')
-    fileExplorers.forEach((fileExplorer) => {
-      Object.entries(fileExplorer.view.fileItems).forEach(
-        ([path, fileItem]) => {
-          ['el', 'selfEl'].forEach(elementType => {
-            const itemClasses = fileItem[elementType].classList.value
-                .split(' ')
-                .filter((cls) => !cls.startsWith('file-color'))
-
-              fileItem[elementType].classList.value = itemClasses.join(' ')
-            })
-       })
-    })
-  }
 }

--- a/src/plugin/FileColorPlugin.ts
+++ b/src/plugin/FileColorPlugin.ts
@@ -104,9 +104,24 @@ export class FileColorPlugin extends Plugin {
           const itemClasses = fileItem.selfEl.classList.value
             .split(' ')
             .filter((cls) => !cls.startsWith('file-color'))
-          const file = this.settings.fileColors.find(
-            (file) => file.path === path
-          )
+
+          let file
+          if (this.settings.inheritColors) {
+            file = this.settings.fileColors.filter(
+              (file) => path.startsWith(file.path)
+            ).sort((fileA, fileB) => {
+              // Get the longest matching path (deeper paths have color priority)
+              if (fileA.path.length === fileB.path.length) {
+                return 0
+              }
+  
+              return fileA.path.length < fileB.path.length ? 1 : -1
+            }).shift() // filter() makes a copy, so we're not changing settings
+          } else {
+            file = this.settings.fileColors.find(
+              (file) => file.path === path
+            )
+          }
 
           if (file) {
             itemClasses.push('file-color-file')

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,4 +1,5 @@
 export type FileColorPluginSettings = {
+  inheritColors: boolean
   palette: Array<{
     id: string
     name: string
@@ -11,6 +12,7 @@ export type FileColorPluginSettings = {
 }
 
 export const defaultSettings: FileColorPluginSettings = {
+  inheritColors: false,
   palette: [],
   fileColors: [],
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,5 +1,6 @@
 export type FileColorPluginSettings = {
   inheritColors: boolean
+  colorBackground: boolean
   palette: Array<{
     id: string
     name: string
@@ -13,6 +14,7 @@ export type FileColorPluginSettings = {
 
 export const defaultSettings: FileColorPluginSettings = {
   inheritColors: false,
+  colorBackground: false,
   palette: [],
   fileColors: [],
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,5 +1,5 @@
 export type FileColorPluginSettings = {
-  inheritColors: boolean
+  cascadeColors: boolean
   colorBackground: boolean
   palette: Array<{
     id: string
@@ -13,7 +13,7 @@ export type FileColorPluginSettings = {
 }
 
 export const defaultSettings: FileColorPluginSettings = {
-  inheritColors: false,
+  cascadeColors: false,
   colorBackground: false,
   palette: [],
   fileColors: [],

--- a/styles.css
+++ b/styles.css
@@ -24,5 +24,5 @@
 /* When inheritance turned on with background, each section looks better with rounded corners.
    They are not rounded above with individual items because that appears to be styled by individual themes already, and we don't want to override them. */
 .workspace-leaf-content[data-type="file-explorer"] .nav-files-container .nav-folder.file-color-file.file-color-type-background {
-  border-radius: 5px;
+  border-radius: var(--radius-s);
 }

--- a/styles.css
+++ b/styles.css
@@ -1,3 +1,4 @@
+/* TEXT COLORING */
 /* These are applied when "inherit" is turned off -- only for individual items */
 .workspace-leaf-content[data-type="file-explorer"] .nav-files-container .nav-folder-title.file-color-file.file-color-type-text,
 .workspace-leaf-content[data-type="file-explorer"] .nav-files-container .nav-file-title.file-color-file.file-color-type-text,
@@ -9,6 +10,7 @@
   color: var(--file-color-color);
 }
 
+/* BACKGROUND COLORING */
 /* These are applied when "inherit" is turned off -- only for individual items */
 .workspace-leaf-content[data-type="file-explorer"] .nav-files-container .nav-folder-title.file-color-file.file-color-type-background,
 .workspace-leaf-content[data-type="file-explorer"] .nav-files-container .nav-file-title.file-color-file.file-color-type-background,
@@ -19,7 +21,8 @@
   background-color: var(--file-color-color);
 }
 
-/* When inheritance turned on with background, each section looks better with rounded corners */
+/* When inheritance turned on with background, each section looks better with rounded corners.
+   They are not rounded above with individual items because that appears to be styled by individual themes already, and we don't want to override them. */
 .workspace-leaf-content[data-type="file-explorer"] .nav-files-container .nav-folder.file-color-file.file-color-type-background {
   border-radius: 5px;
 }

--- a/styles.css
+++ b/styles.css
@@ -18,3 +18,8 @@
 {
   background-color: var(--file-color-color);
 }
+
+/* When inheritance turned on with background, each section looks better with rounded corners */
+.workspace-leaf-content[data-type="file-explorer"] .nav-files-container .nav-folder.file-color-file.file-color-type-background {
+  border-radius: 5px;
+}

--- a/styles.css
+++ b/styles.css
@@ -1,28 +1,27 @@
-/* TEXT COLORING */
-/* These are applied when "inherit" is turned off -- only for individual items */
-.workspace-leaf-content[data-type="file-explorer"] .nav-files-container .nav-folder-title.file-color-file.file-color-type-text,
-.workspace-leaf-content[data-type="file-explorer"] .nav-files-container .nav-file-title.file-color-file.file-color-type-text,
-/* These are applied when "inherit" is turned on -- applies to the whole folder tree */
-.workspace-leaf-content[data-type="file-explorer"] .nav-files-container .nav-folder.file-color-file.file-color-type-text .nav-folder-title,
-.workspace-leaf-content[data-type="file-explorer"] .nav-files-container .nav-folder.file-color-file.file-color-type-text .nav-file-title,
-.workspace-leaf-content[data-type="file-explorer"] .nav-files-container .nav-file.file-color-file.file-color-type-text .nav-file-title /* for top-level notes */
+/* TEXT COLORING, NO CASCADE */
+.workspace-leaf-content[data-type="file-explorer"] .nav-files-container .file-color-file.file-color-type-text > .nav-folder-title,
+.workspace-leaf-content[data-type="file-explorer"] .nav-files-container .file-color-file.file-color-type-text > .nav-file-title
 {
   color: var(--file-color-color);
 }
 
-/* BACKGROUND COLORING */
-/* These are applied when "inherit" is turned off -- only for individual items */
-.workspace-leaf-content[data-type="file-explorer"] .nav-files-container .nav-folder-title.file-color-file.file-color-type-background,
-.workspace-leaf-content[data-type="file-explorer"] .nav-files-container .nav-file-title.file-color-file.file-color-type-background,
-/* These are applied when "inherit" is turned on -- applies to the whole folder tree */
-.workspace-leaf-content[data-type="file-explorer"] .nav-files-container .nav-folder.file-color-file.file-color-type-background,
-.workspace-leaf-content[data-type="file-explorer"] .nav-files-container .nav-file.file-color-file.file-color-type-background
+/* TEXT COLORING, WITH CASCADE */
+.workspace-leaf-content[data-type="file-explorer"] .nav-files-container .file-color-file.file-color-type-text.file-color-cascade .nav-folder-title,
+.workspace-leaf-content[data-type="file-explorer"] .nav-files-container .file-color-file.file-color-type-text.file-color-cascade .nav-file-title
+{
+  color: var(--file-color-color);
+}
+
+/* BACKGROUND COLORING, NO CASCADE */
+.workspace-leaf-content[data-type="file-explorer"] .nav-files-container .file-color-file.file-color-type-background > .nav-folder-title,
+.workspace-leaf-content[data-type="file-explorer"] .nav-files-container .file-color-file.file-color-type-background > .nav-file-title
 {
   background-color: var(--file-color-color);
 }
 
-/* When inheritance turned on with background, each section looks better with rounded corners.
-   They are not rounded above with individual items because that appears to be styled by individual themes already, and we don't want to override them. */
-.workspace-leaf-content[data-type="file-explorer"] .nav-files-container .nav-folder.file-color-file.file-color-type-background {
-  border-radius: var(--radius-s);
+/* BACKGROUND COLORING, WITH CASCADE */
+.workspace-leaf-content[data-type="file-explorer"] .nav-files-container .file-color-file.file-color-type-background.file-color-cascade .nav-folder-title,
+.workspace-leaf-content[data-type="file-explorer"] .nav-files-container .file-color-file.file-color-type-background.file-color-cascade .nav-file-title
+{
+  background-color: var(--file-color-color);
 }

--- a/styles.css
+++ b/styles.css
@@ -1,4 +1,20 @@
-.workspace-leaf-content[data-type="file-explorer"] .nav-files-container .nav-folder-title.file-color-file,
-.workspace-leaf-content[data-type="file-explorer"] .nav-files-container .nav-file-title.file-color-file {
+/* These are applied when "inherit" is turned off -- only for individual items */
+.workspace-leaf-content[data-type="file-explorer"] .nav-files-container .nav-folder-title.file-color-file.file-color-type-text,
+.workspace-leaf-content[data-type="file-explorer"] .nav-files-container .nav-file-title.file-color-file.file-color-type-text,
+/* These are applied when "inherit" is turned on -- applies to the whole folder tree */
+.workspace-leaf-content[data-type="file-explorer"] .nav-files-container .nav-folder.file-color-file.file-color-type-text .nav-folder-title,
+.workspace-leaf-content[data-type="file-explorer"] .nav-files-container .nav-folder.file-color-file.file-color-type-text .nav-file-title,
+.workspace-leaf-content[data-type="file-explorer"] .nav-files-container .nav-file.file-color-file.file-color-type-text .nav-file-title /* for top-level notes */
+{
   color: var(--file-color-color);
+}
+
+/* These are applied when "inherit" is turned off -- only for individual items */
+.workspace-leaf-content[data-type="file-explorer"] .nav-files-container .nav-folder-title.file-color-file.file-color-type-background,
+.workspace-leaf-content[data-type="file-explorer"] .nav-files-container .nav-file-title.file-color-file.file-color-type-background,
+/* These are applied when "inherit" is turned on -- applies to the whole folder tree */
+.workspace-leaf-content[data-type="file-explorer"] .nav-files-container .nav-folder.file-color-file.file-color-type-background,
+.workspace-leaf-content[data-type="file-explorer"] .nav-files-container .nav-file.file-color-file.file-color-type-background
+{
+  background-color: var(--file-color-color);
 }


### PR DESCRIPTION
This PR implements color inheritance as requested in #14, #5

A new option is added in the settings to enable inheritance. If enabled, then if a color is set on a folder, all the children will inherit the same color. Colors set on children will override the parents.

The only slight downside is that if people go crazy with setting colors, it may be difficult to determine which files have colors set. I think it's not a big issue though, since the first different color in the folder hierarchy is the one that has a color set.