### PR TITLE
Simple Fix for switching Workplaces

### DIFF
--- a/src/plugin/FileColorPlugin.ts
+++ b/src/plugin/FileColorPlugin.ts
@@ -32,7 +32,11 @@ export class FileColorPlugin extends Plugin {
     })
 
     this.registerEvent(
-      this.app.workspace.on('layout-change', () => this.applyColorStyles())
+      this.app.workspace.on('layout-change', () => {
+        this.saveSettings(); 
+        this.generateColorStyles();
+        this.applyColorStyles();
+      })
     )
 
     this.registerEvent(

--- a/src/plugin/FileColorPlugin.ts
+++ b/src/plugin/FileColorPlugin.ts
@@ -33,7 +33,6 @@ export class FileColorPlugin extends Plugin {
 
     this.registerEvent(
       this.app.workspace.on('layout-change', () => {
-        this.saveSettings(); 
         this.generateColorStyles();
         this.applyColorStyles();
       })


### PR DESCRIPTION
# Simple Fix for switching Workplaces
I started using this plugin recently and really liked how it looked. I also wanted to use the [homepage](https://github.com/mirnovov/obsidian-homepage) plugin with workspaces but found that when switching to different workspaces the colors go away. This is the issue described in #21 and #7 
I've never used javascript before but wanted to see if I could do something. I noticed when I change a color on the palette in settings after switching to a different workspace the colors worked again.

## Code
I looked in `src/modules/SettingsPanel/index.tsx` and saw that when saving, `plugin.saveSettings()` and `plugin.generateColorStyles()` were being run. I added these to the layout change event and everything works. I then realised the settings don't need (and should not be) saved when the workplace switches, and just using `generateColorStyles()` was enough. 

## Changes: 
I added `this.generateColorStyles()` to `this.app.workspace.on('layout-change', ...)` event.

## Compatibility
Tested with the [homepage](https://github.com/mirnovov/obsidian-homepage) plugin and the [workspace plus](https://github.com/nothingislost/obsidian-workspaces-plus) plugin.
Tested using below folder structure with `Cascade Colors` and `Color Background` turned on. 
![color-file-fix](https://github.com/ecustic/obsidian-file-color/assets/66693748/f9ed2c91-043e-4e0e-b164-93dd97072095)

This is my first pull request, any feedback is appreciated :smile: 
