### PR TITLE
Fix TypeError when file explorer is closed

### DIFF
--- a/src/plugin/FileColorPlugin.ts
+++ b/src/plugin/FileColorPlugin.ts
@@ -101,6 +101,8 @@ export class FileColorPlugin extends Plugin {
 
     const fileExplorers = this.app.workspace.getLeavesOfType('file-explorer')
     fileExplorers.forEach((fileExplorer) => {
+      if (!fileExplorer.view.fileItems) return
+
       Object.entries(fileExplorer.view.fileItems).forEach(
         ([path, fileItem]) => {
           const itemClasses = fileItem.el.classList.value


### PR DESCRIPTION
Fixes console error that occurs when the file explorer view is not open.

The `fileItems` property is null when the file explorer is closed or during layout transitions, causing `Object.entries()` to throw a TypeError. Adding a null check prevents the error without affecting normal operation.

I was seeing this bug very consistently when my file explorer sidebar was closed. Reloading obsidian while the fire explorer sidebar was open make this error condition go away. It seems very safe to guard here so we're not hitting the error state.

<img width="1448" height="214" alt="CleanShot 2026-01-05 at 09 09 28@2x" src="https://github.com/user-attachments/assets/ae449dc3-f79e-440e-9580-ec2c83a8bd97" />
